### PR TITLE
fixed a typo in the documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
 
           <span class="nt">&lt;toggle-switch</span>
             <span class="na">ng-model=</span><span class="s">"switchStatus"</span>
-            <span class="na">class=</span><span class="s">"switch-default"</span><span class="nt">&gt;</span>
+            <span class="na">class=</span><span class="s">"switch-large"</span><span class="nt">&gt;</span>
           <span class="nt">&lt;/toggle-switch&gt;</span>
 
           <span class="nt">&lt;toggle-switch</span>


### PR DESCRIPTION
the documentation in gh-pages referred to switch-large as switch-default. switch-default does not seem to be related to sizes at all.